### PR TITLE
Proof of concept for terminal forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 [![Ember Observer Score](http://emberobserver.com/badges/ember-route-alias.svg)](http://emberobserver.com/addons/ember-route-alias)
 [![Code Climate](https://codeclimate.com/github/nathanhammond/ember-route-alias/badges/gpa.svg)](https://codeclimate.com/github/nathanhammond/ember-route-alias)
 
-This Ember addon makes it easy to create multiple paths to the same route. By default it uses the same set of assets as the original route, but individual assets for each route can be overidden.
+This Ember addon does two things:
+1. **Makes it easy to create multiple paths to the same route** - By default it uses the same set of assets as the original route, but individual assets for each route can be overidden.
+2. **Enables marking routes as invalid terminal (aka leafmost) routes** - Doing so requires declaring what route should actually be the terminal route.
 
 It also includes a simple `{{#rel-link-to}}` helper to make template reuse easier.
 
@@ -46,6 +48,12 @@ Router.map(function() {
 
   this.alias('alias-one', '/alias-one', 'one');
   this.alias('not-one', '/not-one', 'alias-one');
+
+  this.route('non-terminal', function() {
+    this.route('index', { path: '/', terminal: 'non-terminal.terminal' });
+    this.route('sibling', { terminal: 'non-terminal.terminal' });
+    this.route('terminal');
+  });
 });
 ```
 

--- a/tests/acceptance/terminal-test.js
+++ b/tests/acceptance/terminal-test.js
@@ -1,0 +1,29 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import startApp from '../../tests/helpers/start-app';
+
+module('Acceptance | terminal', {
+  beforeEach: function() {
+    this.application = startApp();
+  },
+
+  afterEach: function() {
+    Ember.run(this.application, 'destroy');
+  }
+});
+
+test('visiting non-terminal route ends up on correct page', function(assert) {
+  visit('/non-terminal');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/non-terminal/terminal');
+  });
+});
+
+test('visiting non-terminal route with no path ends up on correct page', function(assert) {
+  visit('/non-terminal/sibling');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/non-terminal/terminal');
+  });
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -24,6 +24,12 @@ Router.map(function() {
 
   this.alias('alias-one', '/alias-one', 'one');
   this.alias('not-one', '/not-one', 'alias-one');
+
+  this.route('non-terminal', function() {
+    this.route('index', { path: '/', terminal: 'non-terminal.terminal' });
+    this.route('sibling', { terminal: 'non-terminal.terminal' });
+    this.route('terminal');
+  });
 });
 
 export default Router;


### PR DESCRIPTION
This PR adds an option that allows declaring a route to be an invalid terminal state, while also declaring what route should actually be visited if someone tries to visit as the terminal route.

TODO:
1. Figure out perf implications
2. Decide on exact API for the current "terminal" option in the dsl
3. Support API for applying the terminal option to the parent instead of the index?
