### PR TITLE
ember-try: Add "ember-1.13" scenario

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
 
 env:
   - EMBER_TRY_SCENARIO=default
+  - EMBER_TRY_SCENARIO=ember-1.13
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -6,6 +6,12 @@ module.exports = {
       dependencies: { }
     },
     {
+      name: 'ember-1.13',
+      dependencies: {
+        'ember': '~1.13.0'
+      }
+    },
+    {
       name: 'ember-release',
       dependencies: {
         'ember': 'components/ember#release'


### PR DESCRIPTION
This PR adds an `ember-1.13` scenario to the `ember-try` configuration and the TravisCI manifest.
