### PR TITLE
Address deprecation warnings

### DIFF
--- a/addon/initializers/route-alias.js
+++ b/addon/initializers/route-alias.js
@@ -96,9 +96,9 @@ function patchRoute(lookup) {
   };
 }
 
-export function initialize(container, application) {
-  // Make this work in 1.X and 2.X.
-  application = application || container;
+export function initialize() {
+  // Make this work in 1.X and 2.X without deprecation warnings.
+  let application = arguments[1] || arguments[0];
 
   // The dictionary we'll be using.
   const lookup = application._routeAliasLookup = {};

--- a/tests/unit/mixins/route-alias-resolver-test.js
+++ b/tests/unit/mixins/route-alias-resolver-test.js
@@ -1,5 +1,5 @@
 // import Ember from 'ember';
-import Resolver from 'ember/resolver';
+import Resolver from 'ember-resolver';
 import RouteAliasResolver from '../../../mixins/route-alias-resolver';
 import { module, test } from 'qunit';
 


### PR DESCRIPTION
Hi! I'm working on an ember app that uses ember 2.6.0 and ember-route-alias 0.1.3, and I have this warning in my browser console:

```
DEPRECATION: The `initialize` method for Application initializer 'route-alias' should take only one argument - `App`, an instance of an `Application`. [deprecation id: ember-application.app-initializer-initialize-arguments] See http://emberjs.com/deprecations/v2.x/#toc_initializer-arity for more details.
```

I followed [the directions to fix this](http://emberjs.com/deprecations/v2.x/#toc_initializer-arity) in such a way as to continue to support ember 1.x. I have confirmed by running my app with my local version of ember-route-alias that this change gets rid of the deprecation warning.

In addition, when I ran the ember-route-alias tests, I got another deprecation warning in the test output, so this PR has a commit to fix that too.

Have a great day! 🌻 
