### PR TITLE
Ensure RouterDSL is only patched once

### DIFF
--- a/addon/initializers/route-alias.js
+++ b/addon/initializers/route-alias.js
@@ -1,5 +1,11 @@
 import Ember from 'ember';
 
+// The addon doesn't support more than one application at a time, so we store the current one
+// and asserts is destroyed before replacing with another one
+let currentApplication;
+// Single lookup table is enough for the same reason
+let lookup;
+
 /*
 Reopen `Ember.Route` to attach a new property to the controller to make it
 available in all route templates. We only need to do this once as it is a global
@@ -13,98 +19,92 @@ Ember.Route.reopen({
 });
 
 // Sets up our magic alias function.
-function createAlias() {
-  Ember.RouterDSL.prototype.alias = function(aliasRoute, aliasPath, aliasTarget) {
-    Ember.assert('You must create a route prior to creating an alias.', this.handlers || this.intercepting);
-    Ember.assert('The alias target must exist before attempting to alias it.', this.handlers[aliasTarget]);
+Ember.RouterDSL.prototype.alias = function(aliasRoute, aliasPath, aliasTarget) {
+  Ember.assert('You must create a route prior to creating an alias.', this.handlers || this.intercepting);
+  Ember.assert('The alias target must exist before attempting to alias it.', this.handlers[aliasTarget]);
 
-    // Grab a reference to the arguments passed in for the original route.
-    let [options, callback] = this.handlers[aliasTarget];
-    options.path = aliasPath;
+  // Grab a reference to the arguments passed in for the original route.
+  let [options, callback] = this.handlers[aliasTarget];
+  options.path = aliasPath;
 
-    this.intercepting.push({ aliasRoute, aliasTarget });
+  this.intercepting.push({ aliasRoute, aliasTarget });
 
-    this.route(aliasRoute, options, callback);
-  };
-}
+  this.route(aliasRoute, options, callback);
+};
 
-// Patches the RouterDSL route function to work with aliases.
-function patchRoute(lookup) {
-  // Save off the original method in scope of the prototype modifications.
-  let originalRouteMethod = Ember.RouterDSL.prototype.route;
+// Save off the original method in scope of the prototype modifications.
+let originalRouteMethod = Ember.RouterDSL.prototype.route;
 
-  // We need to do a few things before and after the original route function.
-  Ember.RouterDSL.prototype.route = function(name, options, callback) {
-    Ember.assert('You may not include a "." in your route name.', !~name.indexOf('.'));
+// We need to do a few things before and after the original route function.
+Ember.RouterDSL.prototype.route = function(name, options, callback) {
+  Ember.assert('You may not include a "." in your route name.', !~name.indexOf('.'));
 
-    // Method signature identification from the original method.
-    if (arguments.length === 2 && typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
+  // Method signature identification from the original method.
+  if (arguments.length === 2 && typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
 
-    if (arguments.length === 1) {
-      options = {};
-    }
+  if (arguments.length === 1) {
+    options = {};
+  }
 
-    // Save off a reference to the original arguments in a reachable scope.
-    // This is so later calls to `alias` have something to find.
-    if (!this.handlers) { this.handlers = {}; }
-    this.handlers[name] = [ options, callback ];
+  // Save off a reference to the original arguments in a reachable scope.
+  // This is so later calls to `alias` have something to find.
+  if (!this.handlers) { this.handlers = {}; }
+  this.handlers[name] = [ options, callback ];
 
-    // For storing the root of the aliased route.
-    if (!this.intercepting) { this.intercepting = []; }
+  // For storing the root of the aliased route.
+  if (!this.intercepting) { this.intercepting = []; }
 
-    // So, we're "recursing" through a structure, but we can sneak in by wrapping the invoked function.
-    if (this.intercepting.length) {
+  // So, we're "recursing" through a structure, but we can sneak in by wrapping the invoked function.
+  if (this.intercepting.length) {
 
-      // Make the callback modify the DSL generated for nested routes.
-      // Necessary so they can register themselves.
-      // Propogate the original interception information forward.
-      var currentIntercepting = this.intercepting[this.intercepting.length - 1];
-      let interceptingCallback = function() {
-        this.intercepting = [currentIntercepting];
-        callback.call(this);
-      };
+    // Make the callback modify the DSL generated for nested routes.
+    // Necessary so they can register themselves.
+    // Propogate the original interception information forward.
+    var currentIntercepting = this.intercepting[this.intercepting.length - 1];
+    let interceptingCallback = function() {
+      this.intercepting = [currentIntercepting];
+      callback.call(this);
+    };
 
-      // Figure out how many routes we created.
-      let originalLength = this.matches.length;
-      originalRouteMethod.call(this, name, options, callback ? interceptingCallback : undefined);
-      let newLength = this.matches.length;
+    // Figure out how many routes we created.
+    let originalLength = this.matches.length;
+    originalRouteMethod.call(this, name, options, callback ? interceptingCallback : undefined);
+    let newLength = this.matches.length;
 
-      // Add each of them to the lookup.
-      for (let i = originalLength; i < newLength; i++) {
-        let intermediate = this.matches[i][1].split('.');
-        let qualifiedAliasRoute = intermediate.join('/');
-        let qualifiedTargetRoute = qualifiedAliasRoute.replace(currentIntercepting.aliasRoute, currentIntercepting.aliasTarget);
+    // Add each of them to the lookup.
+    for (let i = originalLength; i < newLength; i++) {
+      let intermediate = this.matches[i][1].split('.');
+      let qualifiedAliasRoute = intermediate.join('/');
+      let qualifiedTargetRoute = qualifiedAliasRoute.replace(currentIntercepting.aliasRoute, currentIntercepting.aliasTarget);
 
-        if (qualifiedAliasRoute !== qualifiedTargetRoute) {
+      if (qualifiedAliasRoute !== qualifiedTargetRoute) {
+        lookup[qualifiedAliasRoute] = qualifiedTargetRoute;
+      } else {
+        // For index routes we need to try again with the base intercepting object.
+        let isIndex = intermediate.pop().indexOf('index') === 0;
+        qualifiedTargetRoute = qualifiedAliasRoute.replace(this.intercepting[0].aliasRoute, this.intercepting[0].aliasTarget);
+        if (isIndex && qualifiedAliasRoute !== qualifiedTargetRoute) {
           lookup[qualifiedAliasRoute] = qualifiedTargetRoute;
-        } else {
-          // For index routes we need to try again with the base intercepting object.
-          let isIndex = intermediate.pop().indexOf('index') === 0;
-          qualifiedTargetRoute = qualifiedAliasRoute.replace(this.intercepting[0].aliasRoute, this.intercepting[0].aliasTarget);
-          if (isIndex && qualifiedAliasRoute !== qualifiedTargetRoute) {
-            lookup[qualifiedAliasRoute] = qualifiedTargetRoute;
-          }
         }
       }
-
-    } else {
-      originalRouteMethod.call(this, name, options, callback);
     }
-  };
-}
+
+  } else {
+    originalRouteMethod.call(this, name, options, callback);
+  }
+};
 
 export function initialize() {
+  Ember.assert('Addon ember-route-alias has already been initialized for an application. Make sure previous application is destroyed before before creating new one.', !currentApplication || currentApplication.get('isDestroyed'));
+
   // Make this work in 1.X and 2.X without deprecation warnings.
-  let application = arguments[1] || arguments[0];
+  currentApplication = arguments[1] || arguments[0];
 
   // The dictionary we'll be using.
-  const lookup = application._routeAliasLookup = {};
-
-  createAlias();
-  patchRoute(lookup);
+  lookup = currentApplication._routeAliasLookup = {};
 }
 
 export default {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-route-alias",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Ember addon to create multiple paths for the same route.",
   "directories": {
     "doc": "doc",

--- a/tests/unit/initializers/route-alias-test.js
+++ b/tests/unit/initializers/route-alias-test.js
@@ -3,9 +3,6 @@ import RouteAliasInitializer from '../../../initializers/route-alias';
 import { module, test } from 'qunit';
 
 var application;
-var originals = {
-  route: Ember.RouterDSL.prototype.route
-};
 
 module('Unit | Initializer | route alias', {
   beforeEach: function() {
@@ -16,22 +13,9 @@ module('Unit | Initializer | route alias', {
   },
   afterEach: function() {
     Ember.run(function() {
-      delete Ember.RouterDSL.prototype.alias;
-      Ember.RouterDSL.prototype.route = originals.route;
+      application.destroy();
     });
   }
-});
-
-test('Initializer properly modifies/hooks all objects.', function(assert) {
-  RouteAliasInitializer.initialize(application);
-
-  var replacements = {
-    route: Ember.RouterDSL.prototype.route
-  };
-
-  assert.ok(application._routeAliasLookup, 'Ensure that the dictionary we use is present.');
-  assert.notEqual(originals.route, replacements.route, 'RouterDSL#route has been replaced.');
-  assert.ok(Ember.RouterDSL.prototype.route, 'RouterDSL#alias exists.');
 });
 
 test('Route#setupController sets the contextRoute on the controller', function(assert) {
@@ -84,17 +68,20 @@ test('RouterDSL#route saving of scope works as expected.', function(assert) {
 });
 
 test('RouterDSL#route invokes the original prototype.', function(assert) {
-  var spycount = 0;
-  Ember.RouterDSL.prototype.route = function() {
-    spycount++;
-    originals.route.apply(this, arguments);
-  };
-
   RouteAliasInitializer.initialize(application);
   var DSL = new Ember.RouterDSL();
 
+  let matchCalled = 0;
+  function match() {
+    matchCalled++;
+    return {
+      to() {}
+    };
+  }
+
   DSL.route('index', { path: '/' });
-  assert.equal(spycount, 1, 'Invoking route hits the original prototype.');
+  DSL.generate()(match);
+  assert.equal(matchCalled, 1, 'Patched DSL should still generate correct matches');
 });
 
 test('RouterDSL#alias creates the lookup.', function(assert) {


### PR DESCRIPTION
In acceptance tests, multiple applications are created and destroyed. For each of them, the ember-route-alias will patch the Router DSL multiple times, which may lead to unexpected results.

The PR ensures the Router DSL is patched exactly once, but still retains the ability to support multiple applications as long as they don't exist simultaneously. Although, a lot of lines has been changed, the actual change is small:
- added global `lookup` table, which is updated on each initialization. This allows the patched `route` function to access it
- inlined the function patching, so they are patched once, when the module is loaded and never again.
- no other functionality has been changed.

This is one solution to the problem. The biggest hurdle is that the Router DSL is stateless in respect to the application, but the patched functions needs to store state in the application being initialized. To do this properly, the route-alias must store the state the same way the Router DSL do and then collect it when the Router is being initialized, which should make it easier to have access to the application.
