### PR TITLE
Ensure controller is not destroyed before setting contextRoute

### DIFF
--- a/addon/initializers/route-alias.js
+++ b/addon/initializers/route-alias.js
@@ -8,7 +8,10 @@ change that is not instance specific.
 Ember.Route.reopen({
   setupController(controller) {
     this._super.apply(this, arguments);
-    controller.set('contextRoute', this.routeName);
+
+    if (!controller.isDestroyed) {
+      controller.set('contextRoute', this.routeName);
+    }
   }
 });
 


### PR DESCRIPTION
After upgrading to Ember.js 2.13x, I'm getting "calling set on destroyed object" errors when running my acceptance tests. It's not always the same test and is thrown when route-alias initializer reopens and [sets `routeContext` on the controller](https://github.com/nathanhammond/ember-route-alias/blob/687418d50e670319334a7167520427582a2ae9c1/addon/initializers/route-alias.js#L11).

Unfortunately, I have not yet been able to write an isolated test case to reproduce, and the code base manifesting is private. What I do know is that [adding a simple check](https://github.com/cyk/ember-route-alias/commit/e903343f08588b7dfb16e89a3e2e97129821cb03#diff-65f407e2952625a2143fba0ac50687b6R12), seems to resolve this particular issue. **This PR introduces that check.**

Other notes that may be helpful:
- There are multiple acceptance tests with transitions triggered by `link-to` where the target route is an alias for a dynamic route
- This manifest after upgrading from Ember.js v2.12.2 → v2.13.2, Ember-CLI v2.12.3  → v2.13.2
- I've been unable to reproduce using an upgraded 2.13.x branch of ember-route-alias and acceptance tests


