### PR TITLE
Support Ember 2.15.x

### DIFF
--- a/addon/initializers/route-alias.js
+++ b/addon/initializers/route-alias.js
@@ -68,13 +68,14 @@ function patchRoute(lookup) {
       };
 
       // Figure out how many routes we created.
-      let originalLength = this.matches.length;
+      let originalLength = [].concat.apply([], this.matches).length;
       originalRouteMethod.call(this, name, options, callback ? interceptingCallback : undefined);
-      let newLength = this.matches.length;
+      let newMatches = [].concat.apply([], this.matches);
+      let newLength = newMatches.length;
 
       // Add each of them to the lookup.
-      for (let i = originalLength; i < newLength; i++) {
-        let intermediate = this.matches[i][1].split('.');
+      for (let i = originalLength; i < newLength; i += 3) {
+        let intermediate = newMatches[i + 1].split('.');
         let qualifiedAliasRoute = intermediate.join('/');
         let qualifiedTargetRoute = qualifiedAliasRoute.replace(currentIntercepting.aliasRoute, currentIntercepting.aliasTarget);
 

--- a/tests/unit/initializers/route-alias-test.js
+++ b/tests/unit/initializers/route-alias-test.js
@@ -13,7 +13,7 @@ module('Unit | Initializer | route alias', {
       application = Ember.Application.create();
       application.deferReadiness();
       RouteAliasInitializer.initialize(application);
-      DSL = new Ember.RouterDSL(null, {});
+      DSL = new Ember.RouterDSL('application', {});
     });
   }
 });


### PR DESCRIPTION
This would resolve #21 

When Ember bumped to 2.15.x, there was a change on how the `matches` property is defined. Previously it was a multi-dimensional array, but now that array is flattened.

This PR will support 2.15.x and will not break for older versions.

https://github.com/emberjs/ember.js/commit/6d9a9735eeb04182589ff9bd98569288667cb8d8#diff-57d1dbf7bb82d085435a5e830a2e77c7R71
